### PR TITLE
Tweak Allure service resource limits

### DIFF
--- a/openshift/templates/allure/allure-deploy.yaml
+++ b/openshift/templates/allure/allure-deploy.yaml
@@ -333,7 +333,7 @@ parameters:
     displayName: Resources CPU Request
     description: The resources CPU request (in cores) for this build.
     required: true
-    value: 100m
+    value: 1000m
   - name: CPU_LIMIT
     displayName: Resources CPU Limit
     description: The resources CPU limit (in cores) for this build.
@@ -343,7 +343,7 @@ parameters:
     displayName: Resources Memory Request
     description: The resources Memory request (in Mi, Gi, etc) for this build.
     required: true
-    value: 128Mi
+    value: 256Mi
   - name: MEMORY_LIMIT
     displayName: Resources Memory Limit
     description: The resources Memory limit (in Mi, Gi, etc) for this build.


### PR DESCRIPTION
Tweaks to resource limits to ensure reports are correctly generated when more than one project is hosted on the platform.