### PR TITLE
Add support for deploying multiple instances into the same environment

### DIFF
--- a/openshift/manage
+++ b/openshift/manage
@@ -20,11 +20,13 @@ usage () {
 
   Examples:
     $0 -n ggpixq init
+    $0 -n ggpixq -s mobile init
     $0 -n ggpixq -r https://github.com/BcDevOps/allure-framework-openshift.git init
 
     $0 build
 
     $0 -e prod deploy
+    $0 -e prod -s mobile deploy
 
     $0 -e tools clean
     $0 -e prod clean
@@ -33,6 +35,10 @@ usage () {
   ========
     -n Project namespace, the name of the target project minus the environment suffix (-tool, -dev, -test, -prod).
        Used by the 'init' command to set the target project for all subsequent operations.
+
+    -s Optional - Application Suffix
+       Used by the 'init' and 'deploy' commands to set the application suffix for all subsequent deployment operations.
+       You can use this to deploy multiple named application instances in the same environment.
 
     -r Optional - GitHub repository URL
        Used by the 'init' command to set the GitHub for repository for all subsequent build operations.
@@ -84,12 +90,13 @@ export APPLY_LOCAL_SETTINGS=1
 # - The 'getopts' options string must start with ':' for this to work.
 # -----------------------------------------------------------------------------------------------------------------
 while [ ${OPTIND} -le $# ]; do
-  if getopts :n:r:b: FLAG; then
+  if getopts :n:r:b:s: FLAG; then
     case ${FLAG} in
       # List of local options:
       n) PROJECT_NAMESPACE=$OPTARG ;;
       r) GIT_URI=$OPTARG ;;
       b) GIT_REF=$OPTARG ;;
+      s) SUFFIX=$OPTARG ;;
 
       # Pass unrecognized options ...
       \?) pass+=" -${OPTARG}" ;;
@@ -231,8 +238,8 @@ updateParams() {
     _configType=${1}
     _imageTag=${2}
 
-    _allureURL="allure-${PROJECT_NAMESPACE}-${_imageTag}.apps.silver.devops.gov.bc.ca"
-
+    _allureURL="allure${SUFFIX:+-${SUFFIX}}-${PROJECT_NAMESPACE}-${_imageTag}.apps.silver.devops.gov.bc.ca"
+    
     _paramFiles=$(find . -name "*${_configType}.local.param")
     for paramFile in ${_paramFiles}; do
       # Uncomment and update the required deployment settings ...
@@ -248,6 +255,11 @@ updateParams() {
       _parameterFilters="${_parameterFilters}s~\(^ALLURE_PUBLIC_API_URL=\).*$~\1https://${_allureURL}~;"
       _parameterFilters="${_parameterFilters}s~\(^ALLURE_URL=\).*$~\1${_allureURL}~;"
 
+      if [ ! -z "${SUFFIX}" ]; then
+        _parameterFilters="${_parameterFilters}/SUFFIX/s~^#.~~;"
+        _parameterFilters="${_parameterFilters}s~\(^SUFFIX=\).*$~\1-${SUFFIX}~;"
+      fi
+
       cat ${paramFile} | sed ${_parameterFilters} > ${paramFile}.tmp
       rm ${paramFile}
       mv ${paramFile}.tmp ${paramFile}
@@ -261,7 +273,9 @@ deployApp(){
 
     # Deploy or update the configuration ...
     updateDeploymentParams ${DEPLOYMENT_ENV_NAME}
-    if dcExists "allure-ui"; then
+
+    dcName="allure-ui${SUFFIX:+-${SUFFIX}}"
+    if dcExists "${dcName}"; then
       OPERATION=update genDepls.sh -u -l
     else
       genDepls.sh -l
@@ -311,10 +325,12 @@ initialize(){
   echo "  Project namespace: ${PROJECT_NAMESPACE}"
   echo "  Source Repository (used for optional builds): ${GIT_URI}"
   echo "  Source branch (used for optional builds): ${GIT_REF}"
+  if [ ! -z "${SUFFIX}" ]; then
+    echo "  Application Suffix: -${SUFFIX}"
+  fi
 }
 # =================================================================================================================
 pushd ${SCRIPT_HOME} >/dev/null
-shift
 
 case "${_cmd}" in
   init)

--- a/openshift/templates/allure-ui/allure-ui-deploy.yaml
+++ b/openshift/templates/allure-ui/allure-ui-deploy.yaml
@@ -1,9 +1,9 @@
 kind: Template
 apiVersion: v1
 metadata:
-  name: ${NAME}-template
+  name: ${NAME}${SUFFIX}-template
   labels:
-    name: ${NAME}-template
+    name: ${NAME}${SUFFIX}-template
 objects:
   - kind: NetworkPolicy
     apiVersion: networking.k8s.io/v1
@@ -12,7 +12,7 @@ objects:
       labels:
         name: ${NAME}${SUFFIX}-allow-ingress
         app: ${APP_NAME}${SUFFIX}
-        app-group: ${APP_GROUP}
+        app-group: ${APP_GROUP}${SUFFIX}
         role: allure-ui
         env: ${TAG_NAME}
     spec:
@@ -38,8 +38,8 @@ objects:
       generation: 1
       labels:
         name: ${NAME}${SUFFIX}
-        app: ${APP_NAME}
-        app-group: ${APP_GROUP}
+        app: ${APP_NAME}${SUFFIX}
+        app-group: ${APP_GROUP}${SUFFIX}
         role: allure-ui
         env: ${TAG_NAME}
     spec:
@@ -60,16 +60,16 @@ objects:
       test: false
       selector:
         name: ${NAME}${SUFFIX}
-        app: ${APP_NAME}
-        app-group: ${APP_GROUP}
+        app: ${APP_NAME}${SUFFIX}
+        app-group: ${APP_GROUP}${SUFFIX}
         role: allure-ui
         env: ${TAG_NAME}
       template:
         metadata:
           labels:
             name: ${NAME}${SUFFIX}
-            app: ${APP_NAME}
-            app-group: ${APP_GROUP}
+            app: ${APP_NAME}${SUFFIX}
+            app-group: ${APP_GROUP}${SUFFIX}
             role: allure-ui
             env: ${TAG_NAME}
         spec:
@@ -115,8 +115,8 @@ objects:
       name: ${NAME}${SUFFIX}
       labels:
         name: ${NAME}${SUFFIX}
-        app: ${APP_NAME}
-        app-group: ${APP_GROUP}
+        app: ${APP_NAME}${SUFFIX}
+        app-group: ${APP_GROUP}${SUFFIX}
         role: allure-ui
         env: ${TAG_NAME}
     spec:
@@ -134,8 +134,8 @@ objects:
       name: ${NAME}${SUFFIX}
       labels:
         name: ${NAME}${SUFFIX}
-        app: ${APP_NAME}
-        app-group: ${APP_GROUP}
+        app: ${APP_NAME}${SUFFIX}
+        app-group: ${APP_GROUP}${SUFFIX}
         role: allure-ui
         env: ${TAG_NAME}
     spec:
@@ -146,8 +146,8 @@ objects:
           targetPort: 5252
       selector:
         name: ${NAME}${SUFFIX}
-        app: ${APP_NAME}
-        app-group: ${APP_GROUP}
+        app: ${APP_NAME}${SUFFIX}
+        app-group: ${APP_GROUP}${SUFFIX}
         role: allure-ui
         env: ${TAG_NAME}
       type: ClusterIP

--- a/openshift/templates/allure/allure-deploy.yaml
+++ b/openshift/templates/allure/allure-deploy.yaml
@@ -1,9 +1,9 @@
 kind: Template
 apiVersion: v1
 metadata:
-  name: ${NAME}-template
+  name: ${NAME}${SUFFIX}-template
   labels:
-    name: ${NAME}-template
+    name: ${NAME}${SUFFIX}-template
 objects:
   - kind: NetworkPolicy
     apiVersion: networking.k8s.io/v1
@@ -12,7 +12,7 @@ objects:
       labels:
         name: ${NAME}${SUFFIX}-allow-ingress
         app: ${APP_NAME}${SUFFIX}
-        app-group: ${APP_GROUP}
+        app-group: ${APP_GROUP}${SUFFIX}
         role: allure-service
         env: ${TAG_NAME}
     spec:
@@ -38,8 +38,8 @@ objects:
       generation: 1
       labels:
         name: ${NAME}${SUFFIX}
-        app: ${APP_NAME}
-        app-group: ${APP_GROUP}
+        app: ${APP_NAME}${SUFFIX}
+        app-group: ${APP_GROUP}${SUFFIX}
         role: allure-service
         env: ${TAG_NAME}
     spec:
@@ -60,16 +60,16 @@ objects:
       test: false
       selector:
         name: ${NAME}${SUFFIX}
-        app: ${APP_NAME}
-        app-group: ${APP_GROUP}
+        app: ${APP_NAME}${SUFFIX}
+        app-group: ${APP_GROUP}${SUFFIX}
         role: allure-service
         env: ${TAG_NAME}
       template:
         metadata:
           labels:
             name: ${NAME}${SUFFIX}
-            app: ${APP_NAME}
-            app-group: ${APP_GROUP}
+            app: ${APP_NAME}${SUFFIX}
+            app-group: ${APP_GROUP}${SUFFIX}
             role: allure-service
             env: ${TAG_NAME}
         spec:
@@ -148,8 +148,8 @@ objects:
       name: ${NAME}${SUFFIX}-data
       labels:
         name: ${NAME}${SUFFIX}
-        app: ${APP_NAME}
-        app-group: ${APP_GROUP}
+        app: ${APP_NAME}${SUFFIX}
+        app-group: ${APP_GROUP}${SUFFIX}
         role: allure-service
         env: ${TAG_NAME}
     spec:
@@ -166,8 +166,8 @@ objects:
       name: ${NAME}${SUFFIX}
       labels:
         name: ${NAME}${SUFFIX}
-        app: ${APP_NAME}
-        app-group: ${APP_GROUP}
+        app: ${APP_NAME}${SUFFIX}
+        app-group: ${APP_GROUP}${SUFFIX}
         role: allure-service
         env: ${TAG_NAME}
       annotations:
@@ -188,8 +188,8 @@ objects:
       name: ${NAME}${SUFFIX}
       labels:
         name: ${NAME}${SUFFIX}
-        app: ${APP_NAME}
-        app-group: ${APP_GROUP}
+        app: ${APP_NAME}${SUFFIX}
+        app-group: ${APP_GROUP}${SUFFIX}
         role: allure-service
         env: ${TAG_NAME}
     stringData:
@@ -205,8 +205,8 @@ objects:
       name: ${NAME}${SUFFIX}
       labels:
         name: ${NAME}${SUFFIX}
-        app: ${APP_NAME}
-        app-group: ${APP_GROUP}
+        app: ${APP_NAME}${SUFFIX}
+        app-group: ${APP_GROUP}${SUFFIX}
         role: allure-service
         env: ${TAG_NAME}
     spec:
@@ -217,8 +217,8 @@ objects:
           targetPort: 5050
       selector:
         name: ${NAME}${SUFFIX}
-        app: ${APP_NAME}
-        app-group: ${APP_GROUP}
+        app: ${APP_NAME}${SUFFIX}
+        app-group: ${APP_GROUP}${SUFFIX}
         role: allure-service
         env: ${TAG_NAME}
       type: ClusterIP
@@ -323,7 +323,7 @@ parameters:
     displayName: Persistent Volume Size
     description: The size of the persistent volume , e.g. 512Mi, 1Gi, 2Gi.
     required: true
-    value: 2Gi
+    value: 5Gi
   - name: PERSISTENT_VOLUME_CLASS
     displayName: Persistent Volume Class name
     description: The class of the volume; gluster-file, gluster-block, netapp-file-standard, netapp-file-standard, netapp-block-standard

--- a/openshift/templates/nsp/build.yaml
+++ b/openshift/templates/nsp/build.yaml
@@ -14,30 +14,6 @@ objects:
       podSelector: {}
       ingress: []
 
-  - kind: NetworkSecurityPolicy
-    apiVersion: security.devops.gov.bc.ca/v1alpha1
-    metadata:
-      name: any-to-any
-    spec:
-      description: |
-        Disable Aporeto policies - Allow all pods within the namespace to communicate.
-      source:
-        - - $namespace=${NAMESPACE_NAME}-${ENV_NAME}
-      destination:
-        - - $namespace=${NAMESPACE_NAME}-${ENV_NAME}
-
-  - kind: NetworkSecurityPolicy
-    apiVersion: security.devops.gov.bc.ca/v1alpha1
-    metadata:
-      name: any-to-external
-    spec:
-      description: |
-        Disable Aporeto policies - Allow all pods within the namespace full access to external systems.
-      source:
-        - - $namespace=${NAMESPACE_NAME}-${ENV_NAME}
-      destination:
-        - - ext:network=any
-
   - kind: NetworkPolicy
     apiVersion: networking.k8s.io/v1
     metadata:

--- a/openshift/templates/nsp/deploy.yaml
+++ b/openshift/templates/nsp/deploy.yaml
@@ -14,30 +14,6 @@ objects:
       podSelector: {}
       ingress: []
 
-  - kind: NetworkSecurityPolicy
-    apiVersion: security.devops.gov.bc.ca/v1alpha1
-    metadata:
-      name: any-to-any
-    spec:
-      description: |
-        Disable Aporeto policies - Allow all pods within the namespace to communicate.
-      source:
-        - - $namespace=${NAMESPACE_NAME}-${TAG_NAME}
-      destination:
-        - - $namespace=${NAMESPACE_NAME}-${TAG_NAME}
-
-  - kind: NetworkSecurityPolicy
-    apiVersion: security.devops.gov.bc.ca/v1alpha1
-    metadata:
-      name: any-to-external
-    spec:
-      description: |
-        Disable Aporeto policies - Allow all pods within the namespace full access to external systems.
-      source:
-        - - $namespace=${NAMESPACE_NAME}-${TAG_NAME}
-      destination:
-        - - ext:network=any
-
 parameters:
   - name: NAMESPACE_NAME
     displayName: The target namespace for the resources.


### PR DESCRIPTION
- Add support for specifying an application suffix, to uniquely identify multiple instances in the same environment.
- Remove Aporeto Network security policies.  Not needed or supported anymore.

Signed-off-by: Wade Barnes <wade@neoterictech.ca>